### PR TITLE
Support for optional variable values and detection of blank variables

### DIFF
--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -17,6 +17,7 @@ class ENVied
     env!(requested_groups, options)
     error_on_missing_variables!(options)
     error_on_uncoercible_variables!(options)
+    error_on_blank_variables!(options)
 
     ensure_spring_after_fork_require(args, options)
   end
@@ -44,6 +45,15 @@ class ENVied
     end
     if errors.any?
       msg = "The following environment variables are not coercible: #{errors.join(", ")}."
+      msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
+      raise msg
+    end
+  end
+
+  def self.error_on_blank_variables!(options = {})
+    names = env.blank_variables.map(&:name)
+    if names.any?
+      msg = "The following environment variables are empty: #{names * ', '}."
       msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
       raise msg
     end

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -17,6 +17,10 @@ class ENVied
       variables.reject(&method(:coerced?)).reject(&method(:coercible?))
     end
 
+    def blank_variables
+      variables.select(&method(:blank?)).reject(&:allow_blank)
+    end
+
     def variables
       @variables ||= begin
         config.variables.select {|v| groups.include?(v.group) }
@@ -64,6 +68,14 @@ class ENVied
 
     def coerced?(var)
       coercer.coerced?(value_to_coerce(var))
+    end
+
+    # Given a value for an ENVied::Variable, determine if the value is
+    # empty or nil.
+    def blank?(var)
+      val = coerce(var)
+      return true if val.nil?
+      val.respond_to?(:empty?) ? val.empty? : val.nil?
     end
   end
 end

--- a/lib/envied/variable.rb
+++ b/lib/envied/variable.rb
@@ -1,11 +1,12 @@
 class ENVied::Variable
-  attr_reader :name, :type, :group, :default
+  attr_reader :name, :type, :group, :default, :allow_blank
 
   def initialize(name, type, options = {})
     @name = name.to_sym
     @type = type.to_sym
     @group = options.fetch(:group, :default).to_sym
     @default = options[:default]
+    @allow_blank = options.fetch(:allow_blank) { true }
 
     #if !@default.is_a? String
     #  raise ArgumentError, "Default values should be strings (variable #{@name})"

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -98,6 +98,37 @@ describe ENVied do
       end
     end
 
+    context 'ENV variables with "allow_blank" set to false' do
+      before do
+        configuration = configure do
+          variable :STRING_1, :string, allow_blank: false
+          variable :STRING_2, :string, allow_blank: false
+          variable :STRING_3, :string
+
+          variable :ARRAY_1, :array, allow_blank: false
+          variable :ARRAY_2, :array, allow_blank: false
+          variable :ARRAY_3, :array
+
+          variable :HASH_1, :hash, allow_blank: false
+          variable :HASH_2, :hash, allow_blank: false
+          variable :HASH_3, :hash
+        end
+
+        configuration.and_ENV(
+          'STRING_1' => '1', 'STRING_2' => '', 'STRING_3' => '',
+          'BOOL_1' => 'yes', 'BOOL_2' => '', 'BOOL_3' => 'false',
+          'ARRAY_1' => '1,2', 'ARRAY_2' => ',', 'ARRAY_3' => '',
+          'HASH_1' => 'a=1', 'HASH_2' => '', 'HASH_3' => ''
+        )
+      end
+
+      it 'should raise an error specifying which ENV variables are blank' do
+        expect { envied_require }.to(
+          raise_error('The following environment variables are empty: STRING_2, ARRAY_2, HASH_2.')
+        )
+      end
+    end
+
     context 'configuring' do
       it 'raises error when configuring variable of unknown type' do
         expect {


### PR DESCRIPTION
Prior to this changeset, ENVied would happily accept any variables
that were marked as required and had empty values; i.e.: empty
strings, 0-element arrays, and hashes without any key-value pairs.

This commit introduces support for a new option when declaring
variables within an Envfile: `allow_blank`.

By default, all variables will allow blank values in order
to avoid breaking Envfiles that expect this behavior.

Alternatively, setting `allow_blank` to false will raise an error
if variable is considered empty. In effect, this new behavior
provides a sanity check for variables that are required but may
not have been set.

Example Envfile:

``` ruby
variable :STRING_1, :string
variable :STRING_2, :string, allow_blank: false
```

Assuming an environment with the variables
`STRING_1=''` and `STRING_2=''`, running `envied check` would
raise an error stating STRING_2 does not have a non-blank value.
