### PR TITLE
Add support for conditional variables. Fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For the rationale behind this project, see this [blogpost](http://www.gertgoet.c
   * [Types](#types)
   * [Groups](#groups)
   * [Defaults](#defaults)
+  * [Conditionals](#conditionals)
   * [More examples](#more-examples)
 * [Rails](#rails--spring)
 * [Command-line interface](#command-line-interface)
@@ -146,6 +147,29 @@ Don't let setting a default for, say `RAILS_ENV`, give you the impression that `
 As a rule of thumb you should only use defaults:
 * for local development
 * for ENV-variables that are solely used by your application (i.e. for `ENV['STAFF_EMAILS']`, not for `ENV['RAILS_ENV']`)
+
+### Conditionals
+
+Conditionals give you a way to define optional variables.
+
+```ruby
+# file: Envfile
+variable :DB_MASTER_HOST
+variable :DB_MASTER_PORT
+...
+
+conditional :DB_USING_SLAVE do
+  variable :DB_SLAVE_HOST
+  variable :DB_SLAVE_PORT
+  ...
+end
+```
+
+In the above example, if `DB_USING_SLAVE` is `false` then none of the variables
+defined inside of the conditional block are required. The conditional variable
+itself, in this case `DB_USING_SLAVE`, is required.
+
+You can define a type and default on a conditional.
 
 ### More examples
 

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -32,7 +32,10 @@ class ENVied
     end
 
     def has_key?(name)
-      variables_by_name[name.to_sym]
+      variable = variables_by_name[name.to_sym]
+      return unless variable
+      return variable unless variable.conditional
+      coerce(variable.conditional)
     end
 
     def env_value_of(var)
@@ -59,7 +62,8 @@ class ENVied
     end
 
     def missing?(var)
-      value_to_coerce(var).nil?
+      return value_to_coerce(var).nil? unless var.conditional
+      coerce(var.conditional)
     end
 
     def coerced?(var)

--- a/lib/envied/variable.rb
+++ b/lib/envied/variable.rb
@@ -1,11 +1,12 @@
 class ENVied::Variable
-  attr_reader :name, :type, :group, :default
+  attr_reader :name, :type, :group, :default, :conditional
 
   def initialize(name, type, options = {})
     @name = name.to_sym
     @type = type.to_sym
     @group = options.fetch(:group, :default).to_sym
     @default = options[:default]
+    @conditional = options[:conditional]
 
     #if !@default.is_a? String
     #  raise ArgumentError, "Default values should be strings (variable #{@name})"
@@ -18,6 +19,6 @@ class ENVied::Variable
 
   def ==(other)
     self.class == other.class &&
-      [name, type, group, default] == [other.name, other.type, other.group, other.default]
+      [name, type, group, default, conditional] == [other.name, other.type, other.group, other.default, other.conditional]
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -28,6 +28,35 @@ describe ENVied::Configuration do
     end
   end
 
+  describe '#conditional' do
+    def with_envfile(&block)
+      @config = described_class.new(&block)
+    end
+    attr_reader :config
+
+    it 'adds the conditional variable and the variable within the conditional' do
+      with_envfile do
+        conditional :foo do
+          variable :bar, default: 'bar'
+        end
+      end
+
+      foo_var = ENVied::Variable.new(:foo, :boolean)
+      expect(config.variables).to include foo_var
+      expect(config.variables).to include ENVied::Variable.new(:bar, :string, default: 'bar', conditional: foo_var)
+    end
+
+    it 'sets boolean as type when no type is given' do
+      with_envfile do
+        conditional :foo, default: 'false' do
+          variable :bar, default: 'bar'
+        end
+      end
+
+      expect(config.variables).to include ENVied::Variable.new(:foo, :boolean, default: 'false')
+    end
+  end
+
   describe 'defaults' do
     it 'is disabled by default' do
       expect(subject.defaults_enabled?).to_not be

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -224,6 +224,58 @@ describe ENVied do
       end
     end
 
+    describe "conditionals" do
+      context 'a variable in a conditional' do
+        before do
+          configure do
+            conditional :foo do
+              variable :bar
+            end
+          end.and_no_ENV
+        end
+
+        it 'is not required when the conditional is false' do
+          stub_const("ENV", {'foo' => 'false'})
+          expect {
+            envied_require
+          }.not_to raise_error
+        end
+
+        it 'is required when the conditional is true' do
+          stub_const("ENV", {'foo' => 'true'})
+          expect {
+            envied_require
+          }.to raise_error(/bar/)
+        end
+
+        it 'wont define non-required variables on ENVied' do
+          stub_const("ENV", {'foo' => 'false'})
+          envied_require
+
+          expect {
+            described_class.bar
+          }.to raise_error
+        end
+      end
+
+      context 'an empty conditional group' do
+        before do
+          configure do
+            conditional :foo do
+            end
+          end.and_no_ENV
+        end
+
+        it 'wont define the conditional on ENVied' do
+          envied_require
+
+          expect {
+            described_class.foo
+          }.to raise_error
+        end
+      end
+    end
+
     describe "groups" do
       describe 'requiring' do
 


### PR DESCRIPTION
I've added support for conditional variables using the syntax:

``` ruby
conditional :foo do
  variable :bar
end
```

This implements issue #13.
