### PR TITLE
Added URI variable type / coercion

### DIFF
--- a/lib/envied/coercer.rb
+++ b/lib/envied/coercer.rb
@@ -11,6 +11,11 @@ class ENVied::Coercer
       require 'rack/utils'
       ::Rack::Utils.parse_query(str)
     end
+
+    def to_uri(str)
+      require 'uri'
+      ::URI.parse(str)
+    end
   end
   Coercible::Coercer::String.send(:include, CoercerExts)
 
@@ -38,7 +43,7 @@ class ENVied::Coercer
 
   def self.supported_types
     @supported_types ||= begin
-      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string].sort
+      [:hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri].sort
     end
   end
 

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -95,5 +95,13 @@ describe ENVied::Coercer do
         end
       end
     end
+
+    describe 'uri coercion' do
+      let(:coerce){ coerce_to(:Uri) }
+
+      it 'converts strings to uris' do
+        expect(coerce['http://www.google.com']).to be_a(URI)
+      end
+    end
   end
 end


### PR DESCRIPTION
Added support for URI coercion, i.e.

``` ruby
variable :SOME_API_ENDPOINT, :uri, :default => 'https://localhost:9999'
```

which is convenient for doing stuff like:

``` ruby
dashboards_uri = ENVied.SOME_API_ENDPOINT.merge("embed/dashboards")
```

etc..
