### PR TITLE
Do not polute Coercible::Coercer::String

### DIFF
--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -2,6 +2,7 @@ require 'envied/version'
 require 'envied/cli'
 require 'envied/env_proxy'
 require 'envied/coercer'
+require 'envied/coercer/string'
 require 'envied/variable'
 require 'envied/configuration'
 

--- a/lib/envied/coercer.rb
+++ b/lib/envied/coercer.rb
@@ -1,19 +1,5 @@
-require 'coercible'
-
 # Responsible for all string to type coercions.
 class ENVied::Coercer
-  module CoercerExts
-    def to_array(str)
-      str.split(/(?<!\\),/).map{|i| i.gsub(/\\,/,',') }
-    end
-
-    def to_hash(str)
-      require 'rack/utils'
-      ::Rack::Utils.parse_query(str)
-    end
-  end
-  Coercible::Coercer::String.send(:include, CoercerExts)
-
   # Coerce strings to specific type.
   #
   # @param string [String] the string to be coerced
@@ -64,11 +50,11 @@ class ENVied::Coercer
   end
 
   def coercer
-    @coercer ||= Coercible::Coercer.new[String]
+    @coercer ||= Coercible::Coercer.new[ENVied::Coercer::String]
   end
 
   def coerced?(value)
-    !value.kind_of?(String)
+    !value.kind_of?(::String)
   end
 
   def coercible?(string, type)

--- a/lib/envied/coercer/string.rb
+++ b/lib/envied/coercer/string.rb
@@ -1,0 +1,12 @@
+require 'coercible'
+
+class ENVied::Coercer::String < Coercible::Coercer::String
+  def to_array(str)
+    str.split(/(?<!\\),/).map{|i| i.gsub(/\\,/,',') }
+  end
+
+  def to_hash(str)
+    require 'rack/utils'
+    ::Rack::Utils.parse_query(str)
+  end
+end


### PR DESCRIPTION
Instead of polutting clases from other libraries extract coercer to own
class which inherits from original coercer and adds own methods.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/eval/envied/23)

<!-- Reviewable:end -->
