### PR TITLE
Fix typo/bug in check:heroku example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The easiest/quickest is to run:
 $ heroku config | bundle exec envied check:heroku
 ```
 
-This is equivalent to having the heroku config as your local environment and running `envied check --groups default production`.
+This is equivalent to having the heroku config as your local environment and running `envied check:heroku --groups default production`.
 
 You want to run this right before a deploy to Heroku. This prevents that your app will crash during bootup because ENV-variables are missing from heroku config.
 


### PR DESCRIPTION
The `envied check` command, when specifying groups, works slightly different than `envied check:heroku`.