### PR TITLE
Travis: Update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ language: ruby
 before_install:
   - gem update --system
   - gem install bundler
-  - gem update bundler
 
 rvm:
   - 2.1.9
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.0.5.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - jruby-9.1.10.0
   - jruby-head
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.1.9
+  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1


### PR DESCRIPTION
This PR **updates the CI matrix** to the latest generally available Ruby versions.

- use latest releases of Ruby
- gem install bundler installs latest release of Bundler, no need to update it after that

Ruby version numbers can be located at https://github.com/rbenv/ruby-build/tree/master/share/ruby-build