### PR TITLE
Travis: jruby-9.1.14.0, skip gem update --system - it is done by rvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
   - jruby-head
 
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 before_install:
-  - gem update --system
   - gem install bundler
 
 rvm:
@@ -9,7 +8,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
 
 cache: bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html