### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - jruby-9.1.12.0
-  - jruby-head
+  - 2.3.8
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
+  - jruby-9.2.6.0
 
 cache: bundler
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master / unreleased
+
+* Now requiring Ruby version 2.3+
+
 ## 0.9.1 / 2017-07-06
 
 * Updates `envied check:heroku` to support multiline ENV variables [#42](../../pull/42)

--- a/envied.gemspec
+++ b/envied.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.9"
+  spec.required_ruby_version = ">= 2.3"
   spec.add_dependency "coercible", "~> 1.0"
   spec.add_dependency "thor", "~> 0.15"
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/envied.gemspec
+++ b/envied.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
   spec.add_dependency "coercible", "~> 1.0"
   spec.add_dependency "thor", "~> 0.15"
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -23,11 +23,8 @@ class ENVied
   end
 
   def self.env!(requested_groups, options = {})
-    @env = begin
-      @config = options.fetch(:config) { Configuration.load }
-      groups = required_groups(*requested_groups)
-      EnvProxy.new(@config, groups: groups)
-    end
+    @config = options.fetch(:config) { Configuration.load }
+    @env = EnvProxy.new(@config, groups: required_groups(*requested_groups))
   end
 
   def self.error_on_missing_variables!(options = {})

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -58,15 +58,16 @@ class ENVied
 
   def self.ensure_spring_after_fork_require(args, options = {})
     if spring_enabled? && !options[:via_spring]
-      Spring.after_fork { ENVied.require(args, options.merge(:via_spring => true)) }
+      Spring.after_fork { ENVied.require(args, options.merge(via_spring: true)) }
     end
   end
 
   def self.springify(&block)
     if defined?(ActiveSupport::Deprecation.warn) && !required?
-      ActiveSupport::Deprecation.warn(<<-MSG)
-It's no longer recommended to `ENVied.require` within ENVied.springify's block. Please re-run `envied init:rails` to upgrade.
-MSG
+      ActiveSupport::Deprecation.warn(<<~MSG)
+        It's no longer recommended to `ENVied.require` within ENVied.springify's
+        block. Please re-run `envied init:rails` to upgrade.
+      MSG
     end
     if spring_enabled?
       Spring.after_fork(&block)

--- a/lib/envied/cli.rb
+++ b/lib/envied/cli.rb
@@ -43,10 +43,8 @@ class ENVied
       puts "Writing Envfile to #{File.expand_path('Envfile')}"
       template("Envfile.tt")
 
-      puts <<-INIT
-Add the following snippet (or similar) to your app's initialization:
-ENVied.require(*ENV['ENVIED_GROUPS'] || [:default, ENV['RACK_ENV']])
-INIT
+      puts "Add the following snippet (or similar) to your app's initialization:"
+      puts "ENVied.require(*ENV['ENVIED_GROUPS'] || [:default, ENV['RACK_ENV']])"
     end
 
     desc "init:rails", "Generate all files needed for a Rails project"
@@ -79,7 +77,6 @@ INIT
     end
 
     desc "check:heroku", "Checks whether a Heroku config contains required variables"
-
     long_desc <<-LONG
       Checks the config of your Heroku app against the local Envfile.
 
@@ -96,10 +93,7 @@ INIT
     option :quiet, type: :boolean, desc: 'Communicate success of the check only via the exit status.'
     define_method "check:heroku" do
       if STDIN.tty?
-        error <<-ERR
-Please pipe the contents of `heroku config --json` to this task.
-I.e. `heroku config --json | bundle exec envied check:heroku`"
-ERR
+        error "Please pipe to this task i.e. `heroku config --json | bundle exec envied check:heroku`"
         exit 1
       end
       heroku_env = JSON.parse(STDIN.read)
@@ -117,7 +111,6 @@ ERR
       Generates a shell script to check the Heroku config against the local Envfile.
 
       The same as the check:heroku-task, but all in one script (no need to pipe `heroku config --json` to it etc.).
-
     LONG
     option :dest, banner: "where to put the script", desc: "Default: bin/<app>-env-check or bin/heroku-env-check"
     option :app, banner: "name of Heroku app", desc: "uses ENV['HEROKU_APP'] as default if present", default: ENV['HEROKU_APP']

--- a/lib/envied/cli.rb
+++ b/lib/envied/cli.rb
@@ -97,7 +97,7 @@ class ENVied
         exit 1
       end
       heroku_env = JSON.parse(STDIN.read)
-      ENV.replace({}).update(heroku_env)
+      ENV.replace(heroku_env)
 
       requested_groups = ENV['ENVIED_GROUPS'] || options[:groups]
       ENVied.require(*requested_groups)

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -18,13 +18,11 @@ class ENVied
     end
 
     def variables
-      @variables ||= begin
-        config.variables.select {|v| groups.include?(v.group) }
-      end
+      @variables ||= config.variables.select {|v| groups.include?(v.group) }
     end
 
     def variables_by_name
-      Hash[variables.map {|v| [v.name, v] }]
+      @variables_by_name ||= variables.map {|v| [v.name, v] }.to_h
     end
 
     def [](name)

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -5,11 +5,23 @@ describe ENVied::Variable do
     described_class.new(*args)
   end
 
-  def set_env(env)
-    stub_const("ENV", env)
-  end
-
   describe 'an instance' do
     subject { variable(:A, :string) }
+    it { is_expected.to respond_to :name }
+    it { is_expected.to respond_to :type }
+    it { is_expected.to respond_to :group }
+    it { is_expected.to respond_to :default }
+    it { is_expected.to respond_to :== }
+    it { is_expected.to respond_to :default_value }
+  end
+
+  describe 'defaults' do
+    it 'returns the default value as it is' do
+      expect(variable(:A, :string, default: 'A').default_value).to eq 'A'
+    end
+
+    it 'returns the default value from calling the proc provided' do
+      expect(variable(:A, :string, default: ->{ 'A' * 2 }).default_value).to eq 'AA'
+    end
   end
 end


### PR DESCRIPTION
This is an update to the Travis build so we require current maintained Ruby and JRuby versions. Note that 2.3 is EOL at the end of this month but I have left it in place for now. Our `required_ruby_version` is now set to be 2.3 and up.