### PR TITLE
RSpec: Centralize spec_helper, disable monkey patching

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --warnings
 --format progress
 --color
+--require spec_helper

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ENVied::Coercer do
+RSpec.describe ENVied::Coercer do
   it { is_expected.to respond_to :coerce }
 
   describe '#coerce' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ENVied::Configuration do
+RSpec.describe ENVied::Configuration do
   it { is_expected.to respond_to :variable }
   it { is_expected.to respond_to :enable_defaults! }
   it { is_expected.to respond_to :defaults_enabled? }

--- a/spec/env_var_extractor_spec.rb
+++ b/spec/env_var_extractor_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ENVied::EnvVarExtractor do
+RSpec.describe ENVied::EnvVarExtractor do
 
   describe "#capture_variables" do
     def capture_variables(text)

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ENVied do
+RSpec.describe ENVied do
   describe 'class' do
     subject { described_class }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,7 @@ Bundler.setup
 
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'envied'
+
+RSpec.configure do |config| 
+  config.disable_monkey_patching!
+end

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -1,6 +1,4 @@
-require 'spec_helper'
-
-describe ENVied::Variable do
+RSpec.describe ENVied::Variable do
   def variable(*args)
     described_class.new(*args)
   end


### PR DESCRIPTION
This PR moves the require "spec_helper" into the general configuration file for RSpec.

It also [disables the "monkey patching mode".](https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/zero-monkey-patching-mode)