### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.3.8
   - 2.4.5
   - 2.5.5
   - 2.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master / unreleased
 
-* Now requiring Ruby version 2.3+
+* Now requiring Ruby 2.4+
 
 ## 0.9.1 / 2017-07-06
 

--- a/envied.gemspec
+++ b/envied.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
   spec.add_dependency "coercible", "~> 1.0"
   spec.add_dependency "thor", "~> 0.15"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
The Ruby version 2.3 is EOL on 2019-03-31.