### PR TITLE
General code and test suite improvements

### DIFF
--- a/envied.gemspec
+++ b/envied.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "coercible", "~> 1.0"
   spec.add_dependency "thor", "~> 0.15"
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -29,7 +29,7 @@ class ENVied
   def self.error_on_missing_variables!(**options)
     names = env.missing_variables.map(&:name)
     if names.any?
-      msg = "The following environment variables should be set: #{names * ', '}."
+      msg = "The following environment variables should be set: #{names.join(', ')}."
       msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
       raise msg
     end
@@ -37,7 +37,7 @@ class ENVied
 
   def self.error_on_uncoercible_variables!(**options)
     errors = env.uncoercible_variables.map do |v|
-      "%{name} ('%{value}' can't be coerced to %{type})" % {name: v.name, value: env.value_to_coerce(v), type: v.type }
+      format("%{name} with %{value} (%{type})", name: v.name, value: env.value_to_coerce(v).inspect, type: v.type)
     end
     if errors.any?
       msg = "The following environment variables are not coercible: #{errors.join(", ")}."

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -12,8 +12,7 @@ class ENVied
     alias_method :required?, :env
   end
 
-  def self.require(*args)
-    options = args.last.is_a?(Hash) ? args.pop : {}
+  def self.require(*args, **options)
     requested_groups = (args && !args.empty?) ? args : ENV['ENVIED_GROUPS']
     env!(requested_groups, options)
     error_on_missing_variables!(options)
@@ -22,12 +21,12 @@ class ENVied
     ensure_spring_after_fork_require(args, options)
   end
 
-  def self.env!(requested_groups, options = {})
+  def self.env!(requested_groups, **options)
     @config = options.fetch(:config) { Configuration.load }
     @env = EnvProxy.new(@config, groups: required_groups(*requested_groups))
   end
 
-  def self.error_on_missing_variables!(options = {})
+  def self.error_on_missing_variables!(**options)
     names = env.missing_variables.map(&:name)
     if names.any?
       msg = "The following environment variables should be set: #{names * ', '}."
@@ -36,7 +35,7 @@ class ENVied
     end
   end
 
-  def self.error_on_uncoercible_variables!(options = {})
+  def self.error_on_uncoercible_variables!(**options)
     errors = env.uncoercible_variables.map do |v|
       "%{name} ('%{value}' can't be coerced to %{type})" % {name: v.name, value: env.value_to_coerce(v), type: v.type }
     end
@@ -53,7 +52,7 @@ class ENVied
     result.any? ? result.map(&:to_sym) : [:default]
   end
 
-  def self.ensure_spring_after_fork_require(args, options = {})
+  def self.ensure_spring_after_fork_require(args, **options)
     if spring_enabled? && !options[:via_spring]
       Spring.after_fork { ENVied.require(args, options.merge(via_spring: true)) }
     end

--- a/lib/envied/configuration.rb
+++ b/lib/envied/configuration.rb
@@ -2,13 +2,13 @@ class ENVied
   class Configuration
     attr_reader :current_group, :defaults_enabled, :coercer
 
-    def initialize(options = {}, &block)
+    def initialize(**options, &block)
       @coercer = options.fetch(:coercer, Coercer.new)
       @defaults_enabled = options.fetch(:enable_defaults, defaults_enabled_default)
       instance_eval(&block) if block_given?
     end
 
-    def self.load(options = {})
+    def self.load(**options)
       envfile = File.expand_path('Envfile')
       new(options).tap do |v|
         v.instance_eval(File.read(envfile), envfile)
@@ -25,10 +25,7 @@ class ENVied
         @defaults_enabled
     end
 
-    def variable(name, *args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
-      type = args.first || :string
-
+    def variable(name, type = :string, **options)
       unless coercer.supported_type?(type)
         raise ArgumentError, "#{type.inspect} is not a supported type. Should be one of #{coercer.supported_types}"
       end

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -181,7 +181,9 @@ RSpec.describe ENVied::Coercer do
       let(:coerce){ coerce_to(:uri) }
 
       it 'converts strings to uris' do
-        expect(coerce['http://www.google.com']).to be_a(URI)
+        expect(coerce['https://www.google.com']).to be_a(URI)
+        expect(coerce['https://www.google.com'].scheme).to eq 'https'
+        expect(coerce['https://www.google.com'].host).to eq 'www.google.com'
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe ENVied::Configuration do
   it { is_expected.to respond_to :enable_defaults! }
   it { is_expected.to respond_to :defaults_enabled? }
 
-  describe '#variable' do
-    def with_envfile(&block)
-      @config = described_class.new(&block)
-    end
-    attr_reader :config
+  def with_envfile(**options, &block)
+    @config = ENVied::Configuration.new(options, &block)
+  end
+  attr_reader :config
 
+  describe 'variables' do
     it 'results in an added variable' do
       with_envfile do
         variable :foo, :boolean
@@ -55,14 +55,36 @@ RSpec.describe ENVied::Configuration do
       expect(subject.defaults_enabled?).to eq true
     end
 
+    it 'can be enabled through a config option' do
+      with_envfile(enable_defaults: true) { }
+
+      expect(config.defaults_enabled?).to eq true
+    end
+
     describe '#enable_defaults!' do
+      it 'can be enabled in a block by calling `enable_defaults!`' do
+        with_envfile do
+          enable_defaults!
+        end
+
+        expect(config.defaults_enabled?).to eq true
+      end
+
+      it 'can be enabled by calling `enable_defaults!` with a Proc' do
+        with_envfile do
+          enable_defaults! { true }
+        end
+
+        expect(config.defaults_enabled?).to eq true
+      end
+
       it 'defaults to true with no arguments' do
         expect {
           subject.enable_defaults!
         }.to change { subject.defaults_enabled? }.from(false).to(true)
       end
 
-      it 'can be passed a value' do
+      it 'can be passed a boolean value' do
         expect {
           subject.enable_defaults!(true)
         }.to change { subject.defaults_enabled? }.from(false).to(true)

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -4,44 +4,37 @@ RSpec.describe ENVied do
     it { is_expected.to respond_to :require }
   end
 
-  def reset_configuration
-    @config = ENVied::Configuration.new
-  end
-
-  def reset_env
-    ENVied.instance_eval { @env = nil }
-  end
-
-  def reset_envied_config
-    ENVied.instance_eval { @config = nil }
+  def reset_envied
+    ENVied.instance_eval do
+      @env = nil
+      @config = nil
+    end
   end
 
   context 'configured' do
 
     before do
-      reset_env
-      reset_envied_config
-      reset_configuration
-    end
-
-    def configure(options = {}, &block)
-      @config = ENVied::Configuration.new(options, &block)
-    end
-
-    def configured_with(hash = {})
-      @config = ENVied::Configuration.new.tap do |c|
-        hash.each do |name, type|
-          c.variable(name, *type)
-        end
-      end
+      reset_envied
     end
 
     def set_ENV(env = {})
       stub_const("ENV", env)
     end
 
+    def configure(**options, &block)
+      @config = ENVied::Configuration.new(options, &block)
+    end
+
+    def configured_with(**hash)
+      @config = ENVied::Configuration.new.tap do |config|
+        hash.each do |name, type|
+          config.variable(name, type)
+        end
+      end
+    end
+
     def envied_require(*args, **options)
-      options[:config] = @config # we override so Configuration.load is not called
+      options[:config] = @config || ENVied::Configuration.new # Prevent `Configuration.load` from being called
       ENVied.require(*args, **options)
     end
 

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -60,11 +60,9 @@ RSpec.describe ENVied do
       and_ENV
     end
 
-    def envied_require(*args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
-      options[:config] = options[:config] || config
-
-      ENVied.require(*args, options)
+    def envied_require(*args, **options)
+      options[:config] = @config # we override so Configuration.load is not called
+      ENVied.require(*args, **options)
     end
 
     it 'responds to configured variables' do

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe ENVied do
 
     describe 'defaults' do
       describe 'assigning' do
-        it 'can be a value' do
+        it 'sets a default value for ENV variable' do
           configure(enable_defaults: true) do
             variable :A, :integer, default: '1'
           end
@@ -132,7 +132,7 @@ RSpec.describe ENVied do
           expect(described_class.A).to eq 1
         end
 
-        it 'can be a Proc' do
+        it 'sets a default value from calling a proc for ENV variable' do
           configure(enable_defaults: true) do
             variable :A, :integer, default: proc { "1" }
           end
@@ -141,7 +141,7 @@ RSpec.describe ENVied do
           expect(described_class.A).to eq 1
         end
 
-        it 'is ignored if defaults are disabled' do
+        it 'ignores setting defaults if they are disabled' do
           set_ENV
           configure(enable_defaults: false) do
             variable :A, :integer, default: "1"
@@ -153,7 +153,7 @@ RSpec.describe ENVied do
           }.to raise_error(RuntimeError, 'The following environment variables should be set: A, B.')
         end
 
-        it 'is ignored if ENV is provided' do
+        it 'ignores a default value if ENV variable is already provided' do
           set_ENV('A' => '2')
           configure(enable_defaults: true) do
             variable :A, :integer, default: "1"
@@ -163,7 +163,7 @@ RSpec.describe ENVied do
           expect(described_class.A).to eq 2
         end
 
-        it 'can be defined in terms of other variables' do
+        it 'can set a default value via a proc that references another ENV variable' do
           set_ENV('A' => '1')
           configure(enable_defaults: true) do
             variable :A, :integer
@@ -176,9 +176,9 @@ RSpec.describe ENVied do
       end
     end
 
-    describe "::required?" do
+    describe ".required?" do
       # TODO: change to always return boolean
-      it 'yields true-ish when ::require is called' do
+      it 'returns true-ish if `ENVied.require` was called' do
         expect {
           envied_require
         }.to change { ENVied.required? }.from(nil).to(anything)
@@ -187,7 +187,6 @@ RSpec.describe ENVied do
 
     describe "groups" do
       describe 'requiring' do
-
         it 'yields :default when nothing passed to require' do
           envied_require
           expect(ENVied.env.groups).to eq [:default]

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe ENVied do
       reset_configuration
     end
 
-    def config
-      @config
-    end
-
     def configure(options = {}, &block)
       @config = ENVied::Configuration.new(options, &block)
     end
@@ -126,39 +122,6 @@ RSpec.describe ENVied do
     end
 
     describe 'defaults' do
-      describe 'setting' do
-        subject { config }
-
-        it 'is disabled by default' do
-          expect(subject.defaults_enabled?).to eq false
-        end
-
-        it 'is enabled if ENV["ENVIED_ENABLE_DEFAULTS"] is set' do
-          set_ENV('ENVIED_ENABLE_DEFAULTS' => '1')
-          configure
-
-          expect(subject.defaults_enabled?).to eq true
-        end
-
-        it 'can be enabled via config option' do
-          configure(enable_defaults: true) { }
-
-          expect(subject.defaults_enabled?).to eq true
-        end
-
-        it 'can be enabled via a configure-block' do
-          configure { self.enable_defaults! }
-
-          expect(subject.defaults_enabled?).to eq true
-        end
-
-        it 'can be enabled via a Proc' do
-          configure { self.enable_defaults! { true } }
-
-          expect(subject.defaults_enabled?).to eq true
-        end
-      end
-
       describe 'assigning' do
         it 'can be a value' do
           configure(enable_defaults: true) do
@@ -276,7 +239,7 @@ RSpec.describe ENVied do
           }.to_not raise_error
         end
 
-        it 'wont define non-required variables on ENVied' do
+        it 'will not define variables not part of the default group' do
           set_ENV('MORE' => 'yes')
           envied_require(:default)
 

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,0 +1,17 @@
+require "open3"
+
+RSpec.describe 'envied.gemspec' do
+  let!(:build) { Open3.capture3("gem build envied.gemspec") }
+
+  after do
+    Dir.glob("envied-*.gem").each { |f| File.delete(f) }
+  end
+
+  it 'builds without warnings' do
+    expect(build[1]).to_not match(/WARNING/)
+  end
+
+  it 'builds successfully' do
+    expect(build[2].success?).to eq true
+  end
+end


### PR DESCRIPTION
This updates code with quality of life improvements in Ruby like the double splat `**options` usage which we have a few that would cut down on some boilerplate code.

This also updates the incoercible error message format to condense it, as each variable listing does not need the not coercible description that is at the root. An example of what it looks like now:

> The following environment variables are not coercible: A with "NaN" (integer), B with "invalid" (boolean).

Apparently, [its incoercible](https://www.merriam-webster.com/dictionary/incoercible) and not uncoercible. The [latter is considered a typo](http://www.finedictionary.com/Incoercible.html).

Also some further test case improvements and reorganization here. I'm doing these separately from #49 to keep the changes there focused.