### PR TITLE
General updates

### DIFF
--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -2,7 +2,7 @@ class ENVied
   # Responsible for anything related to the ENV.
   class EnvProxy
     attr_reader :config, :coercer, :groups
-    private :config, :coercer#, :groups
+    private :config, :coercer, :groups
 
     def initialize(config, **options)
       @config = config

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -17,14 +17,6 @@ class ENVied
       variables.reject(&method(:coerced?)).reject(&method(:coercible?))
     end
 
-    def variables
-      @variables ||= config.variables.select {|v| groups.include?(v.group) }
-    end
-
-    def variables_by_name
-      @variables_by_name ||= variables.map {|v| [v.name, v] }.to_h
-    end
-
     def [](name)
       coerce(variables_by_name[name.to_sym])
     end
@@ -33,18 +25,12 @@ class ENVied
       variables_by_name[name.to_sym]
     end
 
-    def env_value_of(var)
-      ENV[var.name.to_s]
-    end
-
-    def default_value_of(var)
-      var.default_value(ENVied, var)
-    end
-
     def value_to_coerce(var)
       return env_value_of(var) unless env_value_of(var).nil?
       config.defaults_enabled? ? default_value_of(var) : nil
     end
+
+    private
 
     def coerce(var)
       coerced?(var) ?
@@ -52,16 +38,32 @@ class ENVied
         coercer.coerce(value_to_coerce(var), var.type)
     end
 
+    def coerced?(var)
+      coercer.coerced?(value_to_coerce(var))
+    end
+
     def coercible?(var)
       coercer.coercible?(value_to_coerce(var), var.type)
+    end
+
+    def default_value_of(var)
+      var.default_value(ENVied, var)
+    end
+
+    def env_value_of(var)
+      ENV[var.name.to_s]
     end
 
     def missing?(var)
       value_to_coerce(var).nil?
     end
 
-    def coerced?(var)
-      coercer.coerced?(value_to_coerce(var))
+    def variables
+      @variables ||= config.variables.select {|v| groups.include?(v.group) }
+    end
+
+    def variables_by_name
+      @variables_by_name ||= variables.map {|v| [v.name, v] }.to_h
     end
   end
 end

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -3,7 +3,7 @@ class ENVied
   class EnvProxy
     attr_reader :config, :coercer, :groups
 
-    def initialize(config, options = {})
+    def initialize(config, **options)
       @config = config
       @coercer = options.fetch(:coercer, ENVied::Coercer.new)
       @groups = options.fetch(:groups, [])

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -2,6 +2,7 @@ class ENVied
   # Responsible for anything related to the ENV.
   class EnvProxy
     attr_reader :config, :coercer, :groups
+    private :config, :coercer#, :groups
 
     def initialize(config, **options)
       @config = config

--- a/lib/envied/env_var_extractor.rb
+++ b/lib/envied/env_var_extractor.rb
@@ -15,12 +15,12 @@ class ENVied
 
     attr_reader :globs, :extensions
 
-    def initialize(options = {})
+    def initialize(**options)
       @globs = options.fetch(:globs, self.defaults[:globs])
       @extensions = options.fetch(:extensions, self.defaults[:extensions])
     end
 
-    def self.extract_from(globs, options = {})
+    def self.extract_from(globs, **options)
       new(options.merge(globs: Array(globs))).extract
     end
 

--- a/lib/envied/variable.rb
+++ b/lib/envied/variable.rb
@@ -1,7 +1,7 @@
 class ENVied::Variable
   attr_reader :name, :type, :group, :default
 
-  def initialize(name, type, options = {})
+  def initialize(name, type, **options)
     @name = name.to_sym
     @type = type.to_sym
     @group = options.fetch(:group, :default).to_sym

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe ENVied::Configuration do
 
       expect(config.variables).to include ENVied::Variable.new(:SECRET_KEY_BASE, :string, group: :production)
     end
+
+    it 'sets the same variable for multiple groups' do
+      with_envfile do
+        group :development, :test do
+          variable :DISABLE_PRY, :boolean, default: 'false'
+        end
+      end
+
+      expect(config.variables).to eq [
+        ENVied::Variable.new(:DISABLE_PRY, :boolean, default: 'false', group: :development),
+        ENVied::Variable.new(:DISABLE_PRY, :boolean, default: 'false', group: :test)
+      ]
+    end
   end
 
   describe 'defaults' do


### PR DESCRIPTION
This **adds** an additional **test case to ensure** that **a variable defined in two groups gets created** by the configuration class. We had a test case for only one group. This is a common case so just to ensure it behaves as expected and gives us additional coverage.

Further this tightens up the library a bit by **not exposing all functionality** in various classes **as public**. Many methods are meant to only be private so this makes that interface a bit clearer. This does not include any changes to the `Envied` class methods which could be interacted with. Some methods there I plan to look into adding deprecation warnings for in case they are called directly as they will be made private.