### PR TITLE
Deprecate non-string default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Now requiring Ruby 2.4+ [#48], [#51]
 * Removed `coercible` dependency as now all coercion functionality is implemented locally. This is a backwards compatible change. [#49]
+* Calling `ENVied.required?` now returns an explicit `false` or `true` only value.
 
 ## 0.9.1 / 2017-07-06
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ ENVied.require(:default) #=> Only ENV['FORCE_SSL'] is required
 # On the production server:
 ENVied.require(:default, :production) #=> ...also ENV['SECRET_KEY_BASE'] is required
 
-# You can also pass it a string with the groups separated by comma's:
+# You can also provide the groups as a comma delimited string:
 ENVied.require('default, production')
 
 # This allows for easily requiring groups using the ENV:
@@ -128,7 +128,6 @@ $ ENVIED_GROUPS='default,production' bin/rails server
 ENVied.require
 ENVied.require(:default)
 ENVied.require('default')
-ENVied.require(nil)
 ```
 
 ### Defaults

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -36,8 +36,8 @@ class ENVied
       end
     end
 
-    def error_on_uncoercible_variables!(**options)
-      errors = env.uncoercible_variables.map do |v|
+    def error_on_incoercible_variables!(**options)
+      errors = env.incoercible_variables.map do |v|
         format("%{name} with %{value} (%{type})", name: v.name, value: env.value_to_coerce(v).inspect, type: v.type)
       end
       if errors.any?
@@ -62,8 +62,7 @@ class ENVied
     requested_groups = (args && !args.empty?) ? args : ENV['ENVIED_GROUPS']
     env!(requested_groups, options)
     error_on_missing_variables!(options)
-    error_on_uncoercible_variables!(options)
-
+    error_on_incoercible_variables!(options)
     ensure_spring_after_fork_require(args, options)
   end
 

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -13,6 +13,49 @@ class ENVied
     def required?
       !env.nil?
     end
+
+    private
+
+    def env!(requested_groups, **options)
+      @config = options.fetch(:config) { Configuration.load }
+      @env = EnvProxy.new(@config, groups: required_groups(*requested_groups))
+    end
+
+    def required_groups(*groups)
+      splitter = ->(group){ group.is_a?(String) ? group.split(/ *, */) : group }
+      result = groups.compact.map(&splitter).flatten
+      result.any? ? result.map(&:to_sym) : [:default]
+    end
+
+    def error_on_missing_variables!(**options)
+      names = env.missing_variables.map(&:name)
+      if names.any?
+        msg = "The following environment variables should be set: #{names.join(', ')}."
+        msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
+        raise msg
+      end
+    end
+
+    def error_on_uncoercible_variables!(**options)
+      errors = env.uncoercible_variables.map do |v|
+        format("%{name} with %{value} (%{type})", name: v.name, value: env.value_to_coerce(v).inspect, type: v.type)
+      end
+      if errors.any?
+        msg = "The following environment variables are not coercible: #{errors.join(", ")}."
+        msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
+        raise msg
+      end
+    end
+
+    def ensure_spring_after_fork_require(args, **options)
+      if spring_enabled? && !options[:via_spring]
+        Spring.after_fork { ENVied.require(args, options.merge(via_spring: true)) }
+      end
+    end
+
+    def spring_enabled?
+      defined?(Spring) && Spring.respond_to?(:watcher)
+    end
   end
 
   def self.require(*args, **options)
@@ -22,43 +65,6 @@ class ENVied
     error_on_uncoercible_variables!(options)
 
     ensure_spring_after_fork_require(args, options)
-  end
-
-  def self.env!(requested_groups, **options)
-    @config = options.fetch(:config) { Configuration.load }
-    @env = EnvProxy.new(@config, groups: required_groups(*requested_groups))
-  end
-
-  def self.error_on_missing_variables!(**options)
-    names = env.missing_variables.map(&:name)
-    if names.any?
-      msg = "The following environment variables should be set: #{names.join(', ')}."
-      msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
-      raise msg
-    end
-  end
-
-  def self.error_on_uncoercible_variables!(**options)
-    errors = env.uncoercible_variables.map do |v|
-      format("%{name} with %{value} (%{type})", name: v.name, value: env.value_to_coerce(v).inspect, type: v.type)
-    end
-    if errors.any?
-      msg = "The following environment variables are not coercible: #{errors.join(", ")}."
-      msg << "\nPlease make sure to stop Spring before retrying." if spring_enabled? && !options[:via_spring]
-      raise msg
-    end
-  end
-
-  def self.required_groups(*groups)
-    splitter = ->(group){ group.is_a?(String) ? group.split(/ *, */) : group }
-    result = groups.compact.map(&splitter).flatten
-    result.any? ? result.map(&:to_sym) : [:default]
-  end
-
-  def self.ensure_spring_after_fork_require(args, **options)
-    if spring_enabled? && !options[:via_spring]
-      Spring.after_fork { ENVied.require(args, options.merge(via_spring: true)) }
-    end
   end
 
   def self.springify(&block)
@@ -73,10 +79,6 @@ class ENVied
     else
       block.call
     end
-  end
-
-  def self.spring_enabled?
-    defined?(Spring) && Spring.respond_to?(:watcher)
   end
 
   def self.method_missing(method, *args, &block)

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -80,7 +80,11 @@ class ENVied
   end
 
   def self.method_missing(method, *args, &block)
-    respond_to_missing?(method) ? (env && env[method.to_s]) : super
+    if respond_to_missing?(method)
+      env[method.to_s]
+    else
+      super
+    end
   end
 
   def self.respond_to_missing?(method, include_private = false)

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -9,7 +9,10 @@ require 'envied/configuration'
 class ENVied
   class << self
     attr_reader :env, :config
-    alias_method :required?, :env
+
+    def required?
+      !env.nil?
+    end
   end
 
   def self.require(*args, **options)

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -15,6 +15,11 @@ class ENVied
     end
 
     def uncoercible_variables
+      warn("DEPRECATION WARNING: uncoercible_variables is deprecated and will be removed in a future release. Use incoercible_variables instead.")
+      incoercible_variables
+    end
+
+    def incoercible_variables
       variables.reject(&method(:coerced?)).reject(&method(:coercible?))
     end
 

--- a/lib/envied/errors/incoercible_variables_error.rb
+++ b/lib/envied/errors/incoercible_variables_error.rb
@@ -1,0 +1,9 @@
+class ENVied::IncoercibleVariablesError < RuntimeError
+
+  def self.with(variables)
+    msg = "The following environment variables are not coercible: #{variables.join(", ")}."
+    msg << "\nPlease make sure to stop Spring before retrying." if defined?(::Spring)
+    new(msg)
+  end
+
+end

--- a/lib/envied/errors/missing_variables_error.rb
+++ b/lib/envied/errors/missing_variables_error.rb
@@ -1,0 +1,9 @@
+class ENVied::MissingVariablesError < RuntimeError
+
+  def self.with(variables)
+    msg = "The following environment variables should be set: #{variables.join(', ')}."
+    msg << "\nPlease make sure to stop Spring before retrying." if defined?(::Spring)
+    new(msg)
+  end
+
+end

--- a/lib/envied/variable.rb
+++ b/lib/envied/variable.rb
@@ -10,14 +10,52 @@ class ENVied::Variable
     #if !@default.is_a? String
     #  raise ArgumentError, "Default values should be strings (variable #{@name})"
     #end
+    if !@default.nil? && !@default.respond_to?(:call) && !@default.is_a?(String)
+      deprecate_non_string_default
+    end
   end
 
   def default_value(*args)
-    default.respond_to?(:call) ? default[*args] : default
+    if default.respond_to?(:call)
+      default[*args].tap do |value|
+        deprecate_non_string_default if !value.nil? && !value.is_a?(String)
+      end
+    else
+      default
+    end
   end
 
   def ==(other)
     self.class == other.class &&
       [name, type, group, default] == [other.name, other.type, other.group, other.default]
+  end
+
+  private
+
+  def deprecate_non_string_default
+    warn "DEPRECATION WARNING: Using a non-string default value, will not be supported in a future release and will raise an error. Specify default values as a string to match how it would be set as an environment variable. For example, #{example_message}"
+  end
+
+  def example_message
+    case type
+    when :array
+      "with a `#{type.inspect}` type, use `default: \"1,2,3\"` format instead."
+    when :boolean
+      "with a `#{type.inspect}` type, use `default: \"true\"` format instead."
+    when :date
+      "with a `#{type.inspect}` type, use `default: \"2019-03-23\"` format instead."
+    when :float
+      "with a `#{type.inspect}` type, use `default: \"1.23\"` format instead."
+    when :hash
+      "with a `#{type.inspect}` type, use `default: \"a=1&b=2&c=3\"` format instead."
+    when :integer
+      "with a `#{type.inspect}` type, use `default: \"1\"` format instead."
+    when :symbol
+      "with a `#{type.inspect}` type, use `default: \"my_symbol\"` format instead."
+    when :time
+      "with a `#{type.inspect}` type, use `default: \"2019-03-23 14:30:55\"` format instead."
+    when :uri
+      "with a `#{type.inspect}` type, use `default: \"https://github.com/\"` format instead."
+    end
   end
 end

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -170,11 +170,14 @@ RSpec.describe ENVied do
     end
 
     describe ".required?" do
-      # TODO: change to always return boolean
-      it 'returns true-ish if `ENVied.require` was called' do
+      it 'returns false by default' do
+        expect(ENVied.required?).to eq false
+      end
+
+      it 'returns true if `ENVied.require` was called' do
         expect {
           envied_require
-        }.to change { ENVied.required? }.from(nil).to(anything)
+        }.to change { ENVied.required? }.from(false).to(true)
       end
     end
 

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe ENVied do
           set_ENV('A' => '1')
           configure(enable_defaults: true) do
             variable :A, :integer
-            variable :B, :integer, default: proc {|env| env.A * 2 }
+            variable :B, :integer, default: proc {|env| (env.A * 2).to_s }
           end
           envied_require
 

--- a/spec/envied_spec.rb
+++ b/spec/envied_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ENVied do
       specify do
         expect {
           envied_require
-        }.to raise_error(RuntimeError, 'The following environment variables should be set: A.')
+        }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: A.')
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe ENVied do
         expect {
           envied_require
         }.to raise_error(
-          RuntimeError,
+          ENVied::IncoercibleVariablesError,
           'The following environment variables are not coercible: A with "NaN" (integer), B with "invalid" (boolean).'
         )
       end
@@ -143,7 +143,7 @@ RSpec.describe ENVied do
 
           expect {
             envied_require
-          }.to raise_error(RuntimeError, 'The following environment variables should be set: A, B.')
+          }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: A, B.')
         end
 
         it 'ignores a default value if ENV variable is already provided' do
@@ -200,14 +200,14 @@ RSpec.describe ENVied do
         it 'is required when requiring the groups passed as a delimited string' do
           expect {
             envied_require('foo,moo')
-          }.to raise_error(RuntimeError, 'The following environment variables should be set: BAR, BAT.')
+          }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAR, BAT.')
         end
 
         it 'is required when requiring the group' do
           [:foo, 'foo'].each do |group|
             expect {
               envied_require(group)
-            }.to raise_error(RuntimeError, 'The following environment variables should be set: BAR.')
+            }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAR.')
           end
         end
 
@@ -232,7 +232,7 @@ RSpec.describe ENVied do
           set_ENV('ENVIED_GROUPS' => 'foo')
           expect {
             envied_require
-          }.to raise_error(RuntimeError, 'The following environment variables should be set: BAR.')
+          }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAR.')
         end
 
         it 'will define variables in the default group when nothing is passed to require' do
@@ -246,7 +246,7 @@ RSpec.describe ENVied do
           [:default, 'default'].each do |group|
             expect {
               envied_require(group)
-            }.to raise_error(RuntimeError, 'The following environment variables should be set: MORE.')
+            }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: MORE.')
           end
         end
       end
@@ -266,11 +266,11 @@ RSpec.describe ENVied do
         it 'is required when requiring any of the groups' do
           expect {
             envied_require(:foo)
-          }.to raise_error(RuntimeError, 'The following environment variables should be set: BAR.')
+          }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAR.')
 
           expect {
             envied_require(:moo)
-          }.to raise_error(RuntimeError, 'The following environment variables should be set: BAR.')
+          }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAR.')
         end
       end
 
@@ -303,7 +303,7 @@ RSpec.describe ENVied do
           it 'has no default by default' do
             # fixes a bug where variables of type :Hash had a default even
             # when none was configured.
-            expect { envied_require }.to raise_error(RuntimeError, 'The following environment variables should be set: BAZ.')
+            expect { envied_require }.to raise_error(ENVied::MissingVariablesError, 'The following environment variables should be set: BAZ.')
           end
         end
       end


### PR DESCRIPTION
This is a work in progress for showing a deprecation warning for non-string default values. To improve that we can introduce a `Deprecation` class to wrap this functionality and others such as silence warnings.

This also includes some other improvements that will be moved out into a separate PR.