### PR TITLE
Update thor to a more recent version

### DIFF
--- a/bin/envied
+++ b/bin/envied
@@ -1,5 +1,6 @@
-#!/usr/bin/env ruby -Ilib
+#!/usr/bin/env ruby
 
-require 'envied'
+require "bundler/setup"
+require "envied"
 
 ENVied::Cli.start

--- a/envied.gemspec
+++ b/envied.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", "~> 1.0.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.12"


### PR DESCRIPTION
Rails 6 depends on `thor ~> 1.0.0`, which caused envied to resolve to version `0.5.0`.

This patch updates thor dependency to `~> 1.0.1`