### PR TITLE
Allow envied to add thor with later version

### DIFF
--- a/envied.gemspec
+++ b/envied.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", ">= 0.20"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.12"


### PR DESCRIPTION
Rails 6 is dependent on Thor, leading to dependency clashes with ENVied, which is pinned to a specific version of Thor.